### PR TITLE
Update tags.py

### DIFF
--- a/src/sierra/tags.py
+++ b/src/sierra/tags.py
@@ -1,44 +1,53 @@
 def openTags(any_tag, *args):
-    """Opens any HTML  or XML tag."""
+    """Opens any HTML or XML tag."""
     
-    with open("index.html", 'a') as f:
-        f.write(f"\n<{any_tag}>")
+    with open("index.html", 'a+') as f:
+        f.write(f"<{any_tag}>")
         for arg in args:
-            f.write(f"\n<{arg}>")
-            
+            f.write(f"<{arg}>")
+
 def closeTags(any_tag, *args):
     """Closes any HTML or XML tag."""
     
-    with open("index.html", 'a') as f:
-        f.write(f"\n</{any_tag}>")
+    with open("index.html", 'a+') as f:
+        f.write(f"</{any_tag}>")
         for arg in args:
-            f.write(f"\n</{arg}>")
-            
+            f.write(f"</{arg}>")
+
 def closeTagBefore(tag_to_close, tag_to_close_before):
-    with open("index.html", 'r') as f:
+    with open("index.html", 'r+') as f:
         tag_to_close_before = f"<{tag_to_close_before}>"
         tag_to_close = f"</{tag_to_close}>"
         closed_tag = tag_to_close + f"\n{tag_to_close_before}"
         f = f.read()
         now_closed = f.replace(tag_to_close_before, closed_tag)
-        with open("index.html", 'w') as f:
-            f.write(f"{now_closed}")
-            
-# x = tags()
-# x.openTags('tag3', 'tag1', 'tag2')
-# x.closeTags('tag1', 'tag2')
-# x.close_tag_before('tag3', 'tag2')
+        open("index.html", 'w+').write(now_closed)
+
+#x = tags()
+#x.openTags('tag3', 'tag1', 'tag2')
+#x.closeTags('tag1', 'tag2')
+#x.close_tag_before('tag3', 'tag2')
 
 def closeHTML():
     """Closes the <HTML> tag."""
-    
-    open("index.html", 'a').write(f"\n</html>")
-        
-def openBody(background='False', background_color='white', background_image=False, opacity=False, background_size='cover', background_attachment='fixed', background_position=False, background_repeat=False):
-    """Opens the body tag and adds the required CSS."""
-    
-    open("index.html", 'a').write(f"\n<body>")
-    with open('style.css', 'a') as s:
+    open("index.html", 'a+').write("</html>")
+
+def openBody(background='False', background_color='white', background_image=False, opacity=1.00, background_size='cover', background_attachment='fixed', background_position='center', background_repeat='no-repeat'):
+    """Opens the body tag and adds the required CSS.
+
+    Args:
+        background (str, optional)            : CSS background parameter. Defaults to 'False'.
+        background_color (str, optional)      : CSS background-color parameter. Defaults to 'white'.
+        background_image (str, optional)      : CSS background-image parameter. Defaults to False.
+        opacity (float/int, optional)         : CSS opacity parameter. Defaults to 1.00.
+        background_size (str, optional)       : CSS background-size parameter. Defaults to 'cover'.
+        background_attachment (str, optional) : CSS background-attachment parameter. Defaults to 'fixed'.
+        background_position (str, optional)   : CSS background-position parameter. Defaults to 'center'.
+        background_repeat (str, optional)     : CSS background-repeat parameter. Defaults to 'no-repeat'.
+    """
+
+    open("index.html", 'a+').write(f"\n<body>")
+    with open('style.css', 'a+') as s:
         s.write(f'''
 body {{
     background: {background};
@@ -50,8 +59,7 @@ body {{
     background-position: {background_position};
     background-repeat: {background_repeat};
 }}''')
-        
+
 def closeBody():
-    """Closes the body tag"""
-    
-    open("index.html", 'a').write(f"\n</body>")
+    """Closes the body tag."""
+    open("index.html", 'a+').write("</body>")


### PR DESCRIPTION
- Removed extra `\n`.
- Replaced f-strings with normal strings in some places where formatting was not required.
- Added docstrings for `openBody()`.
- Changed defaults for `openBody()`.
- Changed 'r' mode to 'r+', 'a' mode to 'a+', and 'w' mode to 'w+'.